### PR TITLE
(hopefully) fixed data abort exception and antijam

### DIFF
--- a/include/ui/brainui.hpp
+++ b/include/ui/brainui.hpp
@@ -14,7 +14,7 @@ extern lv_obj_t* ringind;
 
 extern vector<lv_color32_t> colortable;
 extern bool noselection;
-extern int scrpage;
+extern bool scrpage;
 
 namespace jas {
 class jasauton {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -160,7 +160,6 @@ void opcontrol() {
   is_color_sorting = false;
   // This is preference to what you like to drive on
   pros::motor_brake_mode_e_t driver_preference_brake = pros::E_MOTOR_BRAKE_BRAKE;
-  scrpage = 2;
 	lv_event_send(pageswitch, LV_EVENT_CLICKED, NULL);
 //  ladyBrown.set_brake_mode(pros::E_MOTOR_BRAKE_HOLD);
   

--- a/src/subsystems_auton.cpp
+++ b/src/subsystems_auton.cpp
@@ -51,8 +51,8 @@ void discard() {
 }
 
 void unjamTask() {
+  int jamtime = 0;
   while (true) {
-    int jamtime = 0;
     if (!jammed && target != 0 && abs(hook.get_actual_velocity()) <= 20) {
       jamtime++;
       if (jamtime > 20) {

--- a/src/ui/brainui.cpp
+++ b/src/ui/brainui.cpp
@@ -6,7 +6,7 @@ int j = 0;
 int selected = 0;
 int redblustore = 0;
 int posnegstore = 0;
-int scrpage = 0;
+bool scrpage = false;
 vector<jasauton> jautoncurated = {};
 bool noselection;
 bool pageside[2]{true, false};
@@ -149,10 +149,9 @@ static void updownbtn(lv_event_t *e) {
 lv_obj_t *screens[2]{autoselector, motortemps};
 
 static void pageswitchbtn(lv_event_t *e) {
-	const bool *getside = (bool *)lv_event_get_user_data(e);
-	scrpage = *getside ? (scrpage + 1) % 3 : scrpage == 0 ? 2 : (scrpage - 1) % 3;
-	lv_obj_set_tile(mainscreen, screens[scrpage], LV_ANIM_ON);
-	lv_obj_set_parent(pageswitch, screens[scrpage]);
+	scrpage = !scrpage;
+	lv_obj_set_tile(mainscreen, screens[(int)scrpage], LV_ANIM_ON);
+	lv_obj_set_parent(pageswitch, screens[(int)scrpage]);
 }
 
 lv_event_cb_t jautonCurate = jautoncurate;


### PR DESCRIPTION
in antijam, the time counter variable was being recreated every time the loop was run, not allowing it to get anywhere. for the screen, pressing the buttons was attempting to access a screen at an index at the list that didn't exist. i replaced it with a boolean that toggles back and forth, which is how it was before i added the auton builder